### PR TITLE
build(deps): atualiza versão da assembly e pacotes NuGet

### DIFF
--- a/src/OpenAC.Net.NFSe.Nacional.Test/OpenAC.Net.NFSe.Nacional.Test.csproj
+++ b/src/OpenAC.Net.NFSe.Nacional.Test/OpenAC.Net.NFSe.Nacional.Test.csproj
@@ -14,15 +14,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="DotNetEnv" Version="3.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.2" />
+    <PackageReference Include="DotNetEnv" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenAC.Net.NFSe.Nacional/OpenAC.Net.NFSe.Nacional.csproj
+++ b/src/OpenAC.Net.NFSe.Nacional/OpenAC.Net.NFSe.Nacional.csproj
@@ -20,9 +20,9 @@
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <NeutralLanguage>pt-BR</NeutralLanguage>
-        <AssemblyVersion>1.4.5.0</AssemblyVersion>
-        <FileVersion>1.4.5.0</FileVersion>
-        <Version>1.4.5</Version>
+        <AssemblyVersion>1.4.6.0</AssemblyVersion>
+        <FileVersion>1.4.6.0</FileVersion>
+        <Version>1.4.6</Version>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <DebugType>embedded</DebugType>
@@ -60,13 +60,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="OpenAC.Net.Core" Version="1.6.0" />
         <PackageReference Include="OpenAC.Net.DFe.Core" Version="1.6.0.2" />
-        <PackageReference Include="System.Net.Http.Json" Version="10.0.1" />
+        <PackageReference Include="System.Net.Http.Json" Version="10.0.9" />
     </ItemGroup>    
 
     <ItemGroup>


### PR DESCRIPTION
- Atualizada a versão da assembly e do pacote de 1.4.5 para 1.4.6 no projeto principal (OpenAC.Net.NFSe.Nacional).
- Atualizadas as dependências do pacote NuGet no projeto principal (`Microsoft.SourceLink.GitHub` e `System.Net.Http.Json`).
- Atualizadas as dependências do pacote NuGet no projeto de testes (`coverlet.collector`, `DotNetEnv`, `Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, `MSTest.TestFramework` e `System.Formats.Asn1`).